### PR TITLE
Add an option to build and serve the app via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18.14.0-alpine3.17
+
+RUN apk update && apk upgrade
+
+ADD . .
+
+RUN npm install && npm install -D webpack-dev-server && npm run build
+
+CMD [ "npx", "webpack", "serve" ]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ npm run build
 
 Any files changed in the src directory, you will need to run: `npm run build`.
 
+### STEP 3 Alternative
+
+This is entirely optional and is an alternative way to install and run the application. If you'd prefer to use docker instead of installing Node.js then follow these steps:
+
+Requirements: [Docker](https://docs.docker.com/get-docker/)
+
+1. Clone or download this repository.
+2. Navigate to the "aoe4-generated-map-debugger" directory from your command line.
+3. In your command line run these two commands.
+```
+docker build --pull --rm -f "Dockerfile" -t aoe4generatedmapdebugger:latest "."
+docker run -p 9000:9000 aoe4generatedmapdebugger:latest
+```
+4. Open `http://localhost:9000/` with any web browser. Have fun!
+
+Any files changed in the src directory will require you to re-run the commands above.
+
 ## Testing Player Starts
 **IMPORTANT: In order to test player start functions in the debugger you will have to install this tool on your local disk, followed by incorporating Lua scripts. See: [Using Map Functions](#using-map-functions-debug-entire-maps)**
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,5 +57,12 @@ module.exports = {
 			]
 		}),
 		new MiniCssExtractPlugin()
-	]
+	],
+	devServer: {
+		static: {
+		  	directory: path.join(__dirname, 'dist'),
+		},
+		compress: true,
+		port: 9000,
+	},
 }


### PR DESCRIPTION
Hey Drumsin, big fan of this tool I just prefer to run things in docker so thought I'd see if I could add an option to do that. Let me know what you think. I've tested this on my windows 10 machine after following the docker desktop for windows installation and it seems to be doing everything it should.

- Henero from the modding discord